### PR TITLE
Add Kafka topic: test-topic

### DIFF
--- a/topics.yaml
+++ b/topics.yaml
@@ -1,0 +1,8 @@
+# This action will append to existing topics.yaml or create it
+test-topic:
+  partitions: 4
+  retention_ms: 604800000
+  config:
+    cleanup.policy: delete
+    compression.type: snappy
+    min.insync.replicas: 2


### PR DESCRIPTION
## Kafka Topic Configuration

**Topic Name:** `test-topic`
**Partitions:** 4
**Retention:** 604800 seconds (7 days)

This PR adds a new Kafka topic configuration to the topics.yaml file.

### Changes Made:
- Added topic configuration with specified partitions and retention
- Set default cleanup policy to 'delete'
- Configured compression as 'snappy'
- Set min.insync.replicas to 2 for durability

Auto-generated by Backstage Template
